### PR TITLE
mirrorfly-sdk npm version updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lodash.camelcase": "^4.3.0",
     "luxon": "^1.24.1",
     "mic-recorder-to-mp3": "^2.2.2",
-    "mirrorfly-sdk": "^4.16.0",
+    "mirrorfly-sdk": "^4.17.0",
     "moment": "^2.29.4",
     "node-sass": "^7.0.2",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
Release Version: V4.17.0
New Features: 
New mediaDownloadListener call back listener introduced to track media file downloading progress and to cancel the auto downloading
Updates:
apiBaseUrl and isTrialLicenseKey key param have been removed from SDK.initialize() method. SDK will determine these data based on the license key.
